### PR TITLE
RDK-49-Add-screen-at-the-end-of-the-experiment

### DIFF
--- a/Assets/Scenes/DefaultScene.unity
+++ b/Assets/Scenes/DefaultScene.unity
@@ -409,7 +409,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2834388984357925155, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 34255
+      value: 34905
       objectReference: {fileID: 0}
     - target: {fileID: 2896031059644693069, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
       propertyPath: m_IsActive
@@ -445,7 +445,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4267567203292169432, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 64080
+      value: 65280
       objectReference: {fileID: 0}
     - target: {fileID: 4612929069887686480, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
       propertyPath: m_AnchorMax.y
@@ -740,6 +740,7 @@ MonoBehaviour:
   LoadingScreen: {fileID: 439538600}
   LeftEyeTracker: {fileID: 567733400}
   RightEyeTracker: {fileID: 1593745115}
+  RequireFixation: 0
 --- !u!114 &215276331
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
* Add toggle to set fixation to be required or not
* Rename `WaitForCentralFixation` to `IsFixated`
* Fix bug calculating coherence for main trials