### PR TITLE
RDK-79-Refactor-eye-tracking-calibration-to-wait-until-fixation

### DIFF
--- a/Analysis/eye_tracking.jl
+++ b/Analysis/eye_tracking.jl
@@ -107,11 +107,11 @@ function motion_plots()
   df_l = DataFrame([[], [], [], [], [], [], [], [], [], [], []], ["trial_type", "active_visual_field", "time", "eye", "pos_x", "pos_y", "pos_z", "rot_x", "rot_y", "rot_z", "blink"])
   df_r = DataFrame([[], [], [], [], [], [], [], [], [], [], []], ["trial_type", "active_visual_field", "time", "eye", "pos_x", "pos_y", "pos_z", "rot_x", "rot_y", "rot_z", "blink"])
   for (i, row) in enumerate(eachrow(df))
-    left_gaze_data = read_data(row.lefteyeactive_gaze_location_0)
+    left_gaze_data = _read_data(row.lefteyeactive_gaze_location_0)
     left_gaze_data.trial_type .= row.trial_type
     left_gaze_data.active_visual_field .= row.active_visual_field
 
-    right_gaze_data = read_data(row.righteyeactive_gaze_location_0)
+    right_gaze_data = _read_data(row.righteyeactive_gaze_location_0)
     right_gaze_data.trial_type .= row.trial_type
     right_gaze_data.active_visual_field .= row.active_visual_field
 
@@ -197,11 +197,11 @@ function decision_plots()
   df_l = DataFrame([[], [], [], [], [], [], [], [], [], [], []], ["trial_type", "active_visual_field", "time", "eye", "pos_x", "pos_y", "pos_z", "rot_x", "rot_y", "rot_z", "blink"])
   df_r = DataFrame([[], [], [], [], [], [], [], [], [], [], []], ["trial_type", "active_visual_field", "time", "eye", "pos_x", "pos_y", "pos_z", "rot_x", "rot_y", "rot_z", "blink"])
   for (i, row) in enumerate(eachrow(df))
-    left_gaze_data = read_data(row.lefteyeactive_gaze_location_0)
+    left_gaze_data = _read_data(row.lefteyeactive_gaze_location_0)
     left_gaze_data.trial_type .= row.trial_type
     left_gaze_data.active_visual_field .= row.active_visual_field
 
-    right_gaze_data = read_data(row.righteyeactive_gaze_location_0)
+    right_gaze_data = _read_data(row.righteyeactive_gaze_location_0)
     right_gaze_data.trial_type .= row.trial_type
     right_gaze_data.active_visual_field .= row.active_visual_field
 
@@ -210,12 +210,12 @@ function decision_plots()
     right_gaze_data = filter(et_row -> et_row.time >= row.decision_start && et_row.blink < BLINK_THRESHOLD, right_gaze_data)
 
     for left_row in eachrow(left_gaze_data)
-      apply_offsets(left_row)
+      _apply_offsets(left_row)
       push!(df_l, left_row)
     end
 
     for right_row in eachrow(right_gaze_data)
-      apply_offsets(right_row)
+      _apply_offsets(right_row)
       push!(df_r, right_row)
     end
   end

--- a/Analysis/eye_tracking_analysis.jl
+++ b/Analysis/eye_tracking_analysis.jl
@@ -322,7 +322,7 @@ df = filter(row -> startswith(row.trial_type, "Training_") || startswith(row.tri
 df = mapcols(val -> _clean_tracking_paths(val), df, cols=r"lefteyeactive_gaze_location_0")
 df = mapcols(val -> _clean_tracking_paths(val), df, cols=r"righteyeactive_gaze_location_0")
 
-# motion_plots()
-# decision_plots()
-# time_to_fixation()
+motion_plots()
+decision_plots()
+time_to_fixation()
 analyze_fixation_stability()

--- a/Analysis/eye_tracking_analysis.jl
+++ b/Analysis/eye_tracking_analysis.jl
@@ -1,4 +1,4 @@
-using CSV, DataFrames, Plots, StatsPlots, KernelDensity
+using CSV, DataFrames, Plots, StatsPlots, KernelDensity, Statistics
 
 # Path to the results directory
 RESULTS_PATH = "/Analysis/results"
@@ -250,6 +250,57 @@ function time_to_fixation()
   display(p)
 end
 
+function analyze_fixation_stability()
+  # Generate concatenated datasets
+  df_l = DataFrame([[], [], [], [], [], [], [], [], [], [], []], ["trial_type", "active_visual_field", "time", "eye", "pos_x", "pos_y", "pos_z", "rot_x", "rot_y", "rot_z", "blink"])
+  df_r = DataFrame([[], [], [], [], [], [], [], [], [], [], []], ["trial_type", "active_visual_field", "time", "eye", "pos_x", "pos_y", "pos_z", "rot_x", "rot_y", "rot_z", "blink"])
+  for (i, row) in enumerate(eachrow(df))
+    left_gaze_data = _read_data(row.lefteyeactive_gaze_location_0)
+    left_gaze_data.trial_type .= row.trial_type
+    left_gaze_data.active_visual_field .= row.active_visual_field
+
+    right_gaze_data = _read_data(row.righteyeactive_gaze_location_0)
+    right_gaze_data.trial_type .= row.trial_type
+    right_gaze_data.active_visual_field .= row.active_visual_field
+
+    # Filter data to be within the time period where the dot motion is displayed
+    left_gaze_data = filter(et_row -> et_row.time >= row.decision_start && et_row.blink < BLINK_THRESHOLD, left_gaze_data)
+    right_gaze_data = filter(et_row -> et_row.time >= row.decision_start && et_row.blink < BLINK_THRESHOLD, right_gaze_data)
+
+    for left_row in eachrow(left_gaze_data)
+      _apply_offsets(left_row)
+      push!(df_l, left_row)
+    end
+
+    for right_row in eachrow(right_gaze_data)
+      _apply_offsets(right_row)
+      push!(df_r, right_row)
+    end
+  end
+
+  # Calculate standard deviation of gaze positions during fixation periods
+  function get_stability_metrics(x_coords, y_coords)
+    return (
+      std(x_coords),  # X-axis stability
+      std(y_coords),  # Y-axis stability
+      sqrt(std(x_coords)^2 + std(y_coords)^2)  # Overall stability
+    )
+  end
+
+  println("Stability metrics:")
+  # Group by trial type and calculate stability
+  for trial_type in unique(df.trial_type)
+    l_data = filter(row -> row.trial_type == trial_type, df_l)
+    r_data = filter(row -> row.trial_type == trial_type, df_r)
+    l_stability = get_stability_metrics(l_data.pos_x, l_data.pos_y)
+    r_stability = get_stability_metrics(r_data.pos_x, r_data.pos_y)
+
+    println("Trial type: $trial_type")
+    println("\tLeft eye: \t$(round.(l_stability, digits=3))")
+    println("\tRight eye: \t$(round.(r_stability, digits=3))")
+  end
+end
+
 # Check if the trial_results.csv file exists
 if !isfile("trial_results.csv")
   println("Error: trial_results.csv not found, attempting to change directory")
@@ -271,6 +322,7 @@ df = filter(row -> startswith(row.trial_type, "Training_") || startswith(row.tri
 df = mapcols(val -> _clean_tracking_paths(val), df, cols=r"lefteyeactive_gaze_location_0")
 df = mapcols(val -> _clean_tracking_paths(val), df, cols=r"righteyeactive_gaze_location_0")
 
-motion_plots()
-decision_plots()
-time_to_fixation()
+# motion_plots()
+# decision_plots()
+# time_to_fixation()
+analyze_fixation_stability()

--- a/Assets/Scripts/CameraManager.cs
+++ b/Assets/Scripts/CameraManager.cs
@@ -37,7 +37,7 @@ public class CameraManager : MonoBehaviour
     private float _verticalOffset = -2.0f;
 
     private float _stimulusWidth = 0.0f; // Additional world-units to offset the stimulus
-    private float _totalOffset = 0.0f;
+    private float _lateralizedHorizontalOffset = 0.0f;
     private float _stimulusAnchorDistance;
 
     // Camera presentation modes
@@ -61,7 +61,7 @@ public class CameraManager : MonoBehaviour
             _uiAnchor.transform.SetParent(_cameraRig.centerEyeAnchor.transform, false);
             _fixationAnchor.transform.SetParent(_cameraRig.centerEyeAnchor.transform, false);
 
-            CalculateOffset();
+            CalculateLateralizedHorizontalOffset();
         }
     }
 
@@ -69,7 +69,7 @@ public class CameraManager : MonoBehaviour
     /// Calculate the offset distance to accurately present the stimulus 2.5-3 degrees offset from the central
     /// fixation point.
     /// </summary>
-    private void CalculateOffset()
+    private void CalculateLateralizedHorizontalOffset()
     {
         // Calculate required visual offsets for dichoptic presentation
         // Step 1: Calculate IPD
@@ -85,9 +85,15 @@ public class CameraManager : MonoBehaviour
         float offsetDistance = _stimulusAnchorDistance * Mathf.Tan(theta);
 
         // Step 5: Calculate total offset value
-        _totalOffset = offsetDistance + (_stimulusWidth / 2.0f) + (ipd / 2.0f);
+        _lateralizedHorizontalOffset = offsetDistance + (_stimulusWidth / 2.0f) + (ipd / 2.0f);
         Debug.Log("Calculated CameraManager offset distance: " + offsetDistance);
     }
+
+    /// <summary>
+    /// Get the vertical offset of the camera
+    /// </summary>
+    /// <returns>Vertical offset, measured in world units</returns>
+    public float GetVerticalOffset() => _verticalOffset;
 
     /// <summary>
     /// Set the active visual field
@@ -107,7 +113,7 @@ public class CameraManager : MonoBehaviour
             // Left visual presentation
             if (lateralized)
             {
-                _stimulusAnchor.transform.localPosition = new Vector3(0.0f - _totalOffset, 0.0f + _verticalOffset, _stimulusAnchorDistance);
+                _stimulusAnchor.transform.localPosition = new Vector3(0.0f - _lateralizedHorizontalOffset, 0.0f + _verticalOffset, _stimulusAnchorDistance);
             }
 
             if (_useCullingMask)
@@ -121,7 +127,7 @@ public class CameraManager : MonoBehaviour
             // Right visual presentation
             if (lateralized)
             {
-                _stimulusAnchor.transform.localPosition = new Vector3(0.0f + _totalOffset, 0.0f + _verticalOffset, _stimulusAnchorDistance);
+                _stimulusAnchor.transform.localPosition = new Vector3(0.0f + _lateralizedHorizontalOffset, 0.0f + _verticalOffset, _stimulusAnchorDistance);
             }
 
             if (_useCullingMask)
@@ -149,7 +155,7 @@ public class CameraManager : MonoBehaviour
     public void SetStimulusWidth(float width)
     {
         _stimulusWidth = width;
-        CalculateOffset(); // We need to re-calculate the offset values if this has been updated
+        CalculateLateralizedHorizontalOffset(); // We need to re-calculate the offset values if this has been updated
     }
 
     /// <summary>
@@ -170,5 +176,5 @@ public class CameraManager : MonoBehaviour
     /// Get the offset distance, measured in world units
     /// </summary>
     /// <returns>`float` representing the offset distance</returns>
-    public float GetTotalOffset() => _totalOffset;
+    public float GetLateralizedHorizontalOffset() => _lateralizedHorizontalOffset;
 }

--- a/Assets/Scripts/ExperimentManager.cs
+++ b/Assets/Scripts/ExperimentManager.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using UnityEngine;
 
 using UXF;
@@ -761,9 +762,13 @@ public class ExperimentManager : MonoBehaviour
                 yield return StartCoroutine(WaitSeconds(2.0f, true));
                 break;
             case EBlockSequence.Setup:
+                StringBuilder _eyetrackingInstructions = new();
+                _eyetrackingInstructions.Append("A red dot will be visible, and you are to follow the dot movement with your gaze. It will briefly appear green before changing position.\n\n");
+                _eyetrackingInstructions.Append("After a series of movements, the dot will flash before repeating the movements for a second time.\n\n");
+                _eyetrackingInstructions.Append("When you are ready and comfortable, press the <b>Trigger</b> to select <b>Continue</b> and begin.");
                 _uiManager.SetVisible(true);
                 _uiManager.SetHeaderText("Eye-Tracking Setup");
-                _uiManager.SetBodyText("You will be shown a red dot in front of you. Follow the dot movement with your gaze.\n\nAfter a brief series of dot movements, the headset setup will be complete and you will be shown further instructions.\n\n\nWhen you are ready and comfortable, press the <b>Trigger</b> to select <b>Continue</b> and begin.");
+                _uiManager.SetBodyText(_eyetrackingInstructions.ToString());
                 _uiManager.SetLeftButtonState(false, false, "");
                 _uiManager.SetRightButtonState(true, true, "Continue");
 

--- a/Assets/Scripts/SetupManager.cs
+++ b/Assets/Scripts/SetupManager.cs
@@ -279,6 +279,7 @@ public class SetupManager : MonoBehaviour
         // If the number of fixations is greater than or equal to 50, proceed to the next position
         if (gazeData[_fixationObjectPath.Keys.ToList()[_fixationObjectPositionIndex]].Count >= _requiredMeasurements)
         {
+            Debug.Log("Fixation detected at position \"" + _fixationObjectPath.Keys.ToList()[_fixationObjectPositionIndex] + "\", proceeding to next position...");
             _fixationObject.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.green);
             _fixationCanProceed = true;
         }

--- a/Assets/Scripts/SetupManager.cs
+++ b/Assets/Scripts/SetupManager.cs
@@ -9,6 +9,9 @@ using Utilities;
 
 /// <summary>
 /// Manager for headset setup operations. Currently handles setup, operation, and eye-tracking calibration.
+/// Calibration has two phases:
+/// 1. Setup - Move the fixation object around the screen to collect data
+/// 2. Validation - Move the fixation object around the screen to validate the data, with a smaller threshold
 /// </summary>
 public class SetupManager : MonoBehaviour
 {
@@ -27,14 +30,16 @@ public class SetupManager : MonoBehaviour
     private EyePositionTracker _rightEyeTracker;
 
     // Flags for state management
-    private bool _isEyeTrackingSetupActive = false; // 'true' when running calibration operations
     private bool _fixationCanProceed = false; // 'true' when the fixation object can proceed to the next position
-    private bool _isEyeTrackingSetupComplete = false; // 'true' once operations complete
+    private bool _isEyeTrackingCalibrationActive = false; // 'true' when running calibration operations
+    private bool _isEyeTrackingCalibrationSetup = false; // 'true' once the eye tracking calibration is validated
+    private bool _isEyeTrackingCalibrationComplete = false; // 'true' once operations complete
 
     // Set of points to be displayed for fixation and the "path" of the fixation object used
     // for eye-tracking setup
     private readonly float _fixationRadius = 2.4f;
-    private readonly float _fixationThreshold = 0.25f;
+    private readonly float _fixationSetupThreshold = 0.50f;
+    private readonly float _fixationValidationThreshold = 0.25f;
     private GameObject _fixationObject; // Object moved around the screen
     private Vector2 _fixationObjectPosition; // The active unit vector
     private int _fixationObjectPositionIndex = 0;
@@ -51,7 +56,16 @@ public class SetupManager : MonoBehaviour
     private Action _setupCallback; // Optional callback function executed after calibration complete
 
     // Data storage
-    private readonly Dictionary<string, List<GazeVector>> _gazeData = new() {
+    private readonly Dictionary<string, List<GazeVector>> _setupData = new() {
+        {"c_start", new List<GazeVector>() },
+        {"q_1", new List<GazeVector>() },
+        {"q_2", new List<GazeVector>() },
+        {"q_3", new List<GazeVector>() },
+        {"q_4", new List<GazeVector>() },
+        {"c_end", new List<GazeVector>() },
+    };
+
+    private readonly Dictionary<string, List<GazeVector>> _validationData = new() {
         {"c_start", new List<GazeVector>() },
         {"q_1", new List<GazeVector>() },
         {"q_2", new List<GazeVector>() },
@@ -92,18 +106,36 @@ public class SetupManager : MonoBehaviour
     /// <param name="callback">Optional callback function to execute at calibration completion</param>
     public void RunSetup(Action callback = null)
     {
-        _isEyeTrackingSetupActive = true;
-        _fixationObject.SetActive(_isEyeTrackingSetupActive);
+        _isEyeTrackingCalibrationActive = true;
+        _fixationObject.SetActive(_isEyeTrackingCalibrationActive);
 
         // Optional callback function
         _setupCallback = callback;
     }
 
-    private void EndSetup()
+    private void EndCalibrationStage()
     {
-        _isEyeTrackingSetupActive = false;
-        _isEyeTrackingSetupComplete = true;
-        _fixationObject.SetActive(_isEyeTrackingSetupActive);
+        Debug.Log("Ending calibration stage...");
+        if (!_isEyeTrackingCalibrationSetup)
+        {
+            // Completed the setup stage, begin the validation stage
+            _isEyeTrackingCalibrationSetup = true;
+            _isEyeTrackingCalibrationActive = true;
+            Debug.Log("Completed the setup stage, beginning the validation stage...");
+        }
+        else
+        {
+            // Completed the validation stage, end the calibration
+            Debug.Log("Completed the validation stage, ending the calibration...");
+            EndCalibration();
+        }
+    }
+
+    private void EndCalibration()
+    {
+        _isEyeTrackingCalibrationActive = false;
+        _isEyeTrackingCalibrationComplete = true;
+        _fixationObject.SetActive(_isEyeTrackingCalibrationActive);
 
         // Run calculation of gaze offset values
         CalculateOffsetValues();
@@ -115,21 +147,21 @@ public class SetupManager : MonoBehaviour
         _setupCallback?.Invoke();
     }
 
-    public bool GetCalibrationComplete() => _isEyeTrackingSetupComplete;
+    public bool GetCalibrationComplete() => _isEyeTrackingCalibrationComplete;
 
-    public bool GetCalibrationActive() => _isEyeTrackingSetupActive;
+    public bool GetCalibrationActive() => _isEyeTrackingCalibrationActive;
 
     public void SetViewCalibrationVisibility(bool state) => _viewCalibrationPrefabInstance.SetActive(state);
 
     private void CalculateOffsetValues()
     {
         // Function to examine each point and calculate average vector difference from each point
-        foreach (string _unitVectorDirection in _gazeData.Keys)
+        foreach (string _unitVectorDirection in _setupData.Keys)
         {
             var L_vectorSum = Vector2.zero;
             var R_vectorSum = Vector2.zero;
 
-            foreach (var VectorPair in _gazeData[_unitVectorDirection])
+            foreach (var VectorPair in _setupData[_unitVectorDirection])
             {
                 // Get the sum of the gaze vector and the actual position of the dot for each eye
                 var L_result = new Vector2(VectorPair.GetLeft().x, VectorPair.GetLeft().y) + (_fixationObjectPath[_unitVectorDirection] * _fixationRadius);
@@ -139,8 +171,8 @@ public class SetupManager : MonoBehaviour
                 R_vectorSum += new Vector2(VectorPair.GetRight().x, VectorPair.GetRight().y) + (_fixationObjectPath[_unitVectorDirection] * _fixationRadius);
             }
 
-            L_vectorSum /= _gazeData[_unitVectorDirection].Count;
-            R_vectorSum /= _gazeData[_unitVectorDirection].Count;
+            L_vectorSum /= _setupData[_unitVectorDirection].Count;
+            R_vectorSum /= _setupData[_unitVectorDirection].Count;
             _directionalOffsets.Add(_unitVectorDirection, new GazeVector(L_vectorSum, R_vectorSum));
         }
 
@@ -148,14 +180,14 @@ public class SetupManager : MonoBehaviour
         var L_averageOffsetCorrection = Vector2.zero;
         var R_averageOffsetCorrection = Vector2.zero;
 
-        foreach (string _unitVectorDirection in _gazeData.Keys)
+        foreach (string _unitVectorDirection in _setupData.Keys)
         {
             L_averageOffsetCorrection += _directionalOffsets[_unitVectorDirection].GetLeft();
             R_averageOffsetCorrection += _directionalOffsets[_unitVectorDirection].GetRight();
         }
 
-        L_averageOffsetCorrection /= _gazeData.Keys.Count;
-        R_averageOffsetCorrection /= _gazeData.Keys.Count;
+        L_averageOffsetCorrection /= _setupData.Keys.Count;
+        R_averageOffsetCorrection /= _setupData.Keys.Count;
     }
 
     public Dictionary<string, GazeVector> Get_directionalOffsets() => _directionalOffsets;
@@ -175,13 +207,48 @@ public class SetupManager : MonoBehaviour
     /// <param name="l_p">Left eye tracking data</param>
     /// <param name="r_p">Right eye tracking data</param>
     /// <returns>True if the eye tracking data is within the fixation threshold, false otherwise</returns>
-    private bool IsFixated(Vector3 l_p, Vector3 r_p) => Vector2.Distance(l_p, _fixationObject.transform.position) < _fixationThreshold && Vector2.Distance(r_p, _fixationObject.transform.position) < _fixationThreshold;
+    private bool IsFixated(Vector3 l_p, Vector3 r_p)
+    {
+        // Determine which threshold to use based on the current state
+        if (!_isEyeTrackingCalibrationSetup)
+        {
+            // Setup stage, use the setup threshold
+            return Vector2.Distance(l_p, _fixationObject.transform.position) < _fixationSetupThreshold && Vector2.Distance(r_p, _fixationObject.transform.position) < _fixationSetupThreshold;
+        }
+        else
+        {
+            // Validation stage, use the validation threshold
+            return Vector2.Distance(l_p, _fixationObject.transform.position) < _fixationValidationThreshold && Vector2.Distance(r_p, _fixationObject.transform.position) < _fixationValidationThreshold;
+        }
+    }
+
+    private void RunGazeCapture()
+    {
+        // Capture eye tracking data and store alongside location
+        var l_p = _leftEyeTracker.GetGazeEstimate();
+        var r_p = _rightEyeTracker.GetGazeEstimate();
+
+        // Determine which data dictionary to use based on the current state
+        var gazeData = _isEyeTrackingCalibrationSetup ? _validationData : _setupData;
+
+        // Test fixation and add to the appropriate data dictionary
+        if (IsFixated(l_p, r_p))
+        {
+            gazeData[_fixationObjectPath.Keys.ToList()[_fixationObjectPositionIndex]].Add(new(l_p, r_p));
+        }
+
+        // If the number of fixations is greater than or equal to 50, proceed to the next position
+        if (gazeData[_fixationObjectPath.Keys.ToList()[_fixationObjectPositionIndex]].Count >= 50)
+        {
+            _fixationObject.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.green);
+            _fixationCanProceed = true;
+        }
+    }
 
     private void Update()
     {
-        if (_isEyeTrackingSetupActive)
+        if (_isEyeTrackingCalibrationActive)
         {
-
             if (_fixationCanProceed)
             {
                 _updateTimer += Time.deltaTime;
@@ -192,7 +259,7 @@ public class SetupManager : MonoBehaviour
                     if (_fixationObjectPositionIndex > _fixationObjectPath.Count - 1)
                     {
                         _fixationObjectPositionIndex = 0;
-                        EndSetup();
+                        EndCalibrationStage();
                     }
                     _fixationObjectPosition = _fixationObjectPath[_fixationObjectPath.Keys.ToList()[_fixationObjectPositionIndex]];
                     _fixationObject.transform.localPosition = new Vector3(_fixationObjectPosition.x * _fixationRadius, _fixationObjectPosition.y * _fixationRadius, 0.0f);
@@ -205,21 +272,7 @@ public class SetupManager : MonoBehaviour
             }
             else
             {
-                // Capture eye tracking data and store alongside location
-                var l_p = _leftEyeTracker.GetGazeEstimate();
-                var r_p = _rightEyeTracker.GetGazeEstimate();
-
-                if (IsFixated(l_p, r_p))
-                {
-                    _gazeData[_fixationObjectPath.Keys.ToList()[_fixationObjectPositionIndex]].Add(new(l_p, r_p));
-                }
-
-                // If the number of fixations is greater than or equal to 50, proceed to the next position
-                if (_gazeData[_fixationObjectPath.Keys.ToList()[_fixationObjectPositionIndex]].Count >= 50)
-                {
-                    _fixationObject.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.green);
-                    _fixationCanProceed = true;
-                }
+                RunGazeCapture();
             }
         }
     }

--- a/Assets/Scripts/SetupManager.cs
+++ b/Assets/Scripts/SetupManager.cs
@@ -34,7 +34,7 @@ public class SetupManager : MonoBehaviour
     // Set of points to be displayed for fixation and the "path" of the fixation object used
     // for eye-tracking setup
     private readonly float _fixationRadius = 2.4f;
-    private readonly float _fixationThreshold = 0.5f;
+    private readonly float _fixationThreshold = 0.25f;
     private GameObject _fixationObject; // Object moved around the screen
     private Vector2 _fixationObjectPosition; // The active unit vector
     private int _fixationObjectPositionIndex = 0;
@@ -79,7 +79,7 @@ public class SetupManager : MonoBehaviour
 
         // Set initial position of fixation object
         _fixationObjectPosition = _fixationObjectPath[_fixationObjectPath.Keys.ToList()[_fixationObjectPositionIndex]];
-        _fixationObject.transform.position = new Vector3(_fixationObjectPosition.x * _fixationRadius, _fixationObjectPosition.y * _fixationRadius, 10.0f);
+        _fixationObject.transform.localPosition = new Vector3(_fixationObjectPosition.x * _fixationRadius, _fixationObjectPosition.y * _fixationRadius, 0.0f);
 
         // Setup the calibration prefab instance, initially hidden
         _viewCalibrationPrefabInstance = Instantiate(_viewCalibrationPrefab, _stimulusAnchor.transform);
@@ -195,7 +195,7 @@ public class SetupManager : MonoBehaviour
                         EndSetup();
                     }
                     _fixationObjectPosition = _fixationObjectPath[_fixationObjectPath.Keys.ToList()[_fixationObjectPositionIndex]];
-                    _fixationObject.transform.position = new Vector3(_fixationObjectPosition.x * _fixationRadius, _fixationObjectPosition.y * _fixationRadius, 10.0f);
+                    _fixationObject.transform.localPosition = new Vector3(_fixationObjectPosition.x * _fixationRadius, _fixationObjectPosition.y * _fixationRadius, 0.0f);
 
                     // Reset the timer, fixation flag, and the color of the fixation object
                     _updateTimer = 0.0f;

--- a/Assets/Scripts/SetupManager.cs
+++ b/Assets/Scripts/SetupManager.cs
@@ -39,8 +39,8 @@ public class SetupManager : MonoBehaviour
     // Set of points to be displayed for fixation and the "path" of the fixation object used
     // for eye-tracking setup
     private readonly float _fixationRadius = 2.4f;
-    private readonly float _fixationSetupThreshold = 0.50f;
-    private readonly float _fixationValidationThreshold = 0.25f;
+    private readonly float _fixationSetupThreshold = 0.70f;
+    private readonly float _fixationValidationThreshold = 0.50f;
     private readonly int _requiredMeasurements = 100;
     private GameObject _fixationObject; // Object moved around the screen
     private Vector2 _fixationObjectPosition; // The active unit vector


### PR DESCRIPTION
* Add two stages to eye-tracking calibration:
  * `setup`: Higher fixation threshold
  * `validation`: Lower fixation threshold
* Added more functions to eye-tracking data analysis script.
* Future work will address applying a global calibration adjustment to the gaze estimates.
