### PR TITLE
RDK-73-Add-data-column-specifying-if-low-or-high-coherence-was-used-in-main-trials

### DIFF
--- a/Assets/Scenes/DefaultScene.unity
+++ b/Assets/Scenes/DefaultScene.unity
@@ -409,7 +409,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2834388984357925155, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 65975
+      value: 66105
       objectReference: {fileID: 0}
     - target: {fileID: 2896031059644693069, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
       propertyPath: m_IsActive
@@ -445,7 +445,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4267567203292169432, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 122640
+      value: 122880
       objectReference: {fileID: 0}
     - target: {fileID: 4612929069887686480, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
       propertyPath: m_AnchorMax.y

--- a/Assets/Scripts/ExperimentManager.cs
+++ b/Assets/Scripts/ExperimentManager.cs
@@ -630,18 +630,30 @@ public class ExperimentManager : MonoBehaviour
         else if (trial == ETrialType.Main_Trials_Binocular)
         {
             _activeCoherence = UnityEngine.Random.value > 0.5 ? _mainBinocularCoherence.Item1 : _mainBinocularCoherence.Item2;
+
+            // Store if the high or low coherence was selected
+            Session.instance.CurrentTrial.result["main_binocular_coherence_type"] = _activeCoherence == _mainBinocularCoherence.Item1 ? "low" : "high";
+            Debug.Log("Coherence type: " + Session.instance.CurrentTrial.result["main_binocular_coherence_type"]);
         }
         else if (trial is ETrialType.Main_Trials_Monocular_Left or ETrialType.Main_Trials_Monocular_Right)
         {
             // Select the appropriate coherence pair (left or right), then select a coherence value (low or high)
             var CoherencePair = _activeVisualField == CameraManager.EVisualField.Left ? _mainMonocularCoherenceLeft : _mainMonocularCoherenceRight;
             _activeCoherence = UnityEngine.Random.value > 0.5 ? CoherencePair.Item1 : CoherencePair.Item2;
+
+            // Store if the high or low coherence was selected
+            Session.instance.CurrentTrial.result["main_monocular_coherence_type"] = _activeCoherence == CoherencePair.Item1 ? "low" : "high";
+            Debug.Log("Coherence type: " + Session.instance.CurrentTrial.result["main_monocular_coherence_type"]);
         }
         else if (trial is ETrialType.Main_Trials_Lateralized_Left or ETrialType.Main_Trials_Lateralized_Right)
         {
             // Select the appropriate coherence pair (left or right), then select a coherence value (low or high)
             var CoherencePair = _activeVisualField == CameraManager.EVisualField.Left ? _mainLateralizedCoherenceLeft : _mainLateralizedCoherenceRight;
             _activeCoherence = UnityEngine.Random.value > 0.5 ? CoherencePair.Item1 : CoherencePair.Item2;
+
+            // Store if the high or low coherence was selected
+            Session.instance.CurrentTrial.result["main_lateralized_coherence_type"] = _activeCoherence == CoherencePair.Item1 ? "low" : "high";
+            Debug.Log("Coherence type: " + Session.instance.CurrentTrial.result["main_lateralized_coherence_type"]);
         }
 
         // Apply coherence value (RDK-70)


### PR DESCRIPTION
* Add a column to the data containing a simple `low` or `high` depending on which coherence value was selected during the `main_`-type trial.