### PR TITLE
RDK-81-Operate-experiment-setup-via-remote-control-panel

### DIFF
--- a/Assets/Scripts/ExperimentManager.cs
+++ b/Assets/Scripts/ExperimentManager.cs
@@ -767,12 +767,12 @@ public class ExperimentManager : MonoBehaviour
                 StringBuilder _eyetrackingInstructions = new();
                 _eyetrackingInstructions.Append("A red dot will be visible, and you are to follow the dot movement with your gaze. It will briefly appear green before changing position.\n\n");
                 _eyetrackingInstructions.Append("After a series of movements, the dot will flash before repeating the movements for a second time.\n\n");
-                _eyetrackingInstructions.Append("When you are ready and comfortable, press the <b>Trigger</b> to select <b>Continue</b> and begin.");
+                _eyetrackingInstructions.Append("Notify the facilitator when you are ready to continue.");
                 _uiManager.SetVisible(true);
                 _uiManager.SetHeaderText("Eye-Tracking Setup");
                 _uiManager.SetBodyText(_eyetrackingInstructions.ToString());
                 _uiManager.SetLeftButtonState(false, false, "");
-                _uiManager.SetRightButtonState(true, true, "Continue");
+                _uiManager.SetRightButtonState(false, false, "");
 
                 // Input delay
                 yield return StartCoroutine(WaitSeconds(0.25f, true));

--- a/Assets/Scripts/Monitoring/HeadsupServer.cs
+++ b/Assets/Scripts/Monitoring/HeadsupServer.cs
@@ -49,6 +49,16 @@ namespace Monitoring
                 _gazeManager.SetRequireFixation(true);
                 Send(JsonConvert.SerializeObject("Fixation Enabled"));
             }
+            else if (e.Data == "start_task")
+            {
+                _experiment.StartTask();
+                Send(JsonConvert.SerializeObject("Started Task"));
+            }
+            else if (e.Data == "start_calibration")
+            {
+                _experiment.StartCalibration();
+                Send(JsonConvert.SerializeObject("Started Calibration"));
+            }
             else if (e.Data == "screenshot")
             {
                 // Capture screenshot of current view


### PR DESCRIPTION
* Add new commands from `Headsup` to allow the fit screen and calibration to be run remotely and triggered via control panel.
* Add new monitoring state variables to act on received commands.
* Update the pre-setup instructions to remove button and text about the trigger.